### PR TITLE
Slightly hot fix for decoding errors. Helps #57.

### DIFF
--- a/pythonwhois/net.py
+++ b/pythonwhois/net.py
@@ -14,7 +14,7 @@ def get_whois_raw(domain, server="", previous=None, rfc3490=True, never_cut=Fals
 		# The following is a bit hacky, but IANA won't return the right answer for example.com because it's a direct registration.
 		"example.com": "whois.verisign-grs.com"
 	}
-	
+
 	if rfc3490:
 		if sys.version_info < (3, 0):
 			domain = encode( domain if type(domain) is unicode else decode(domain, "utf8"), "idna" )
@@ -71,7 +71,7 @@ def get_whois_raw(domain, server="", previous=None, rfc3490=True, never_cut=Fals
 		return (new_list, server_list)
 	else:
 		return new_list
-	
+
 def get_root_server(domain):
 	data = whois_request(domain, "whois.iana.org")
 	for line in [x.strip() for x in data.splitlines()]:
@@ -80,7 +80,7 @@ def get_root_server(domain):
 			continue
 		return match.group(1)
 	raise shared.WhoisException("No root WHOIS server found for domain.")
-	
+
 def whois_request(domain, server, port=43):
 	sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 	sock.connect((server, port))
@@ -91,4 +91,10 @@ def whois_request(domain, server, port=43):
 		if len(data) == 0:
 			break
 		buff += data
-	return buff.decode("utf-8")
+	encodings = ("utf-8", "iso-8859-1")
+	for encoding in encodings: # This should probably not be a permanent solution.
+		try:
+			return buff.decode(encoding)
+		except ValueError:
+			pass
+	raise ValueError("Could not decode whois response from {server}".format(server=server))


### PR DESCRIPTION
Now no longer raises a UnicodeDecodeError when running into invalid
UTF-8 characters, but tries iso-8859-1 first instead.